### PR TITLE
Make tooltips readable.

### DIFF
--- a/packages/basic-light/src/index.ts
+++ b/packages/basic-light/src/index.ts
@@ -32,7 +32,7 @@ const invalid = '#d30102',
   darkBackground = base06,
   highlightBackground = darkBackground,
   background = '#ffffff',
-  tooltipBackground = base01,
+  tooltipBackground = base05,
   selection = darkBackground,
   cursor = base01
 


### PR DESCRIPTION
This fixes a problem where the tooltips are unreadable in this theme, because they are near-black text on a near-black background.